### PR TITLE
Add pinned manifest file psa-storage-test-pinned-manifest.xml.

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -80,7 +80,7 @@ PSA_CRYPTO_DIR=mbed-crypto
 PSA_STORAGE_DIR=psa_trusted_storage_linux
 PSA_STORAGE_MANIFEST_NAME=psa-storage-test-manifest.xml
 PSA_STORAGE_PINNED_MANIFEST_NAME=psa-storage-test-pinned-manifest.xml
-PSA_STORAGE_REPO_BRANCH=sdh_iotmbl_2532	# TODO: replace with master after merged
+PSA_STORAGE_REPO_BRANCH=master
 
 # TEST_DIR is the location where PSA storage object files are created/removed
 # as part of testing. The path is specified as

--- a/test/psa-storage-test-manifest.xml
+++ b/test/psa-storage-test-manifest.xml
@@ -6,10 +6,10 @@
   <remote fetch="ssh://git@github.com" name="github"/>
   <default revision="master" sync-j="4"/>
 
-  <project name="armmbed/psa_trusted_storage_linux" path="psa_trusted_storage_linux" remote="github" revision="sdh_iotmbl_2532">
+  <project name="armmbed/psa_trusted_storage_linux" path="psa_trusted_storage_linux" remote="github" revision="master">
     <linkfile dest="Makefile" src="test/Makefile"/>
   </project>
-  <project name="simonqhughes/psa-arch-tests" path="psa-arch-tests" remote="github" revision="sdh_iotmbl_2532"/>
+  <project name="simonqhughes/psa-arch-tests" path="psa-arch-tests" remote="github" revision="feature-psa-storage"/>
   <project name="armmbed/mbed-crypto" path="mbed-crypto" remote="github" revision="development"/>
 
 </manifest>

--- a/test/psa-storage-test-pinned-manifest.xml
+++ b/test/psa-storage-test-pinned-manifest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remote fetch="ssh://git@github.com" name="github"/>
+  
+  <default revision="master" sync-j="4"/>
+  
+  <project name="armmbed/mbed-crypto" path="mbed-crypto" remote="github" revision="6b2a779323d77ceb3437e38766ad38841e4f9ca8" upstream="development"/>
+  <project name="armmbed/psa_trusted_storage_linux" path="psa_trusted_storage_linux" remote="github" revision="6614755a25241d6874ef6cab70f0999e9a8be3b2" upstream="sdh_iotmbl_2532">
+    <linkfile dest="Makefile" src="test/Makefile"/>
+  </project>
+  <project name="simonqhughes/psa-arch-tests" path="psa-arch-tests" remote="github" revision="a219c5b1c9c7083e01f6b52eeab3dc36a11b6d93" upstream="sdh_iotmbl_2532"/>
+</manifest>


### PR DESCRIPTION
This manifest allows a known-good workspace to be recreated.
A build of this pinned workspace includes the following:
- Workspace Makefile build and test support.
- PSA Storage compliance test binary psa-arch-tests-ps support.
- Fix PSA Storage Test 403 (Insufficient space check).
- Fix PSA Storage Test 406 (Flags not supported check).
- Fix PSA Storage Test 408 (Invalid offset check).
- Fix PSA Storage Test 410 (UID value zero check).