### PR TITLE
Add Makefile suppport to build libpsastorage.a static library.

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -24,7 +24,7 @@ TARGET_APP = psa-storage-example-app
 
 CFLAGS ?= -O2 -g
 LOCAL_CFLAGS ?= -Wall -W -Wdeclaration-after-statement -I../inc
-LOCAL_LDFLAGS = ../lib/libpsastorage.so.$(major)
+LOCAL_LDFLAGS = ../lib/libpsastorage.a
 
 SRCS = main.c
 OBJS = $(SRCS:.c=.o)

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -21,11 +21,13 @@ RM = rm -f
 CFLAGS ?= -O2 -g
 LOCAL_CFLAGS ?= -fPIC -Wall -Wextra -I../inc
 LOCAL_LDFLAGS ?= -shared
+LOCAL_ARFLAGS ?= rcs
 TARGET_NAME = libpsastorage
 
 SOLINKERNAME = $(TARGET_NAME).so
 SONAME = $(TARGET_NAME).so.$(major)
 TARGET_LIB = $(SONAME).$(minor).$(rel)
+STATIC_LIB = $(TARGET_NAME).a
 
 SRCS = \
 	common_storage.c \
@@ -35,11 +37,14 @@ SRCS = \
 OBJS = $(SRCS:.c=.o)
 
 .PHONY: all
-all: ${TARGET_LIB}
+all: ${TARGET_LIB} $(STATIC_LIB)
 
 $(TARGET_LIB): $(OBJS)
 	$(CC) ${LDFLAGS} $(LOCAL_LDFLAGS) -o $@ $^
 	ln -sf $(TARGET_LIB) $(SONAME)
+
+$(STATIC_LIB): $(OBJS)
+	$(AR) $(LOCAL_ARFLAGS) $@ $^
 
 $(SRCS:.c=.d):%.d:%.c
 	$(CC) $(CFLAGS) $(LOCAL_CFLAGS) -MM $< >$@
@@ -51,10 +56,11 @@ include $(SRCS:.c=.d)
 
 .PHONY: clean
 clean:
-	$(RM) $(TARGET_LIB) $(SONAME) $(SOLINKERNAME) $(OBJS) $(SRCS:.c=.d)
+	$(RM) $(TARGET_LIB) $(STATIC_LIB) $(SONAME) $(SOLINKERNAME) $(OBJS) $(SRCS:.c=.d)
 
 .PHONY: install
 install:
 	$(INSTALL) -D $(TARGET_LIB) -t $(libdir)
 	cd $(libdir) && ln -sf $(TARGET_LIB) $(SONAME)
 	cd $(libdir) && ln -sf $(SONAME) $(SOLINKERNAME)
+	$(INSTALL) -D $(STATIC_LIB) -t $(libdir)


### PR DESCRIPTION
The following provides more information on this commit:
- 0001-Create-static-library-target.patch was supplied by Ionut Mihalcea.
  This commit applied the patch and submits a PR.
- app/Makefile is updated to use the libpsastroage.a for
  psa-storage-example-app.